### PR TITLE
Update rule.php

### DIFF
--- a/rule.php
+++ b/rule.php
@@ -639,6 +639,25 @@ class quizaccess_sebserver extends access_rule_base {
         ];
     }
     /**
+     * Setup attempt page
+     *
+     * @param stdClass page
+     * set header earlier so that Safe Exam Browser can detect proctoring using SAML2 method of login
+     */
+    
+    public function setup_attempt_page($page) {
+        global $USER;
+
+        // Force session init or preload
+        if (isloggedin() && !isguestuser()) {
+                // You could log this or preload something
+                header("X-LMS-USER-ID: $USER->id");
+                header("X-LMS-USER-USERNAME: $USER->username");
+                header("X-LMS-USER-EMAIL: $USER->email");
+                header("X-LMS-USER-IDNUMBER: $USER->idnumber");
+        }
+    }
+    /**
      * Calls Rest API of SebServer.
      *
      * @param string $url end point.


### PR DESCRIPTION

This pull request introduces a new method, `setup_attempt_page`, to the `rule.php` file to enhance the setup process for attempt pages. The primary purpose of this method is to set HTTP headers early in the page lifecycle, enabling Safe Exam Browser (SEB) to detect proctoring using the SAML2 login method.

### Key Changes:

#### Enhancements to attempt page setup:
* **New method `setup_attempt_page`:** 
  - Added to set HTTP headers (`X-LMS-USER-*`) with user information (e.g., ID, username, email, and ID number) for logged-in, non-guest users.
  - Ensures session initialization or preloading for compatibility with SEB proctoring requirements.