### PR TITLE
Removal of redirect message

### DIFF
--- a/middleman.php
+++ b/middleman.php
@@ -42,6 +42,4 @@ $PAGE->set_pagelayout('redirect');  // No header and footer needed.
 $PAGE->set_title(get_string('pageshouldredirect', 'moodle'));
 
 $CFG->docroot = false;
-$message = get_string('pageshouldredirect');
-$delay = 5;
-echo $OUTPUT->redirect_message($urltogo, $message, $delay, false);
+echo '<meta http-equiv="refresh" content="0; url=' . $urltogo . '" />';

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025052703;
+$plugin->version   = 2025061300;
 $plugin->requires  = 2023042400.00; // Requires Moodle 4.2.
 $plugin->supported = [402, 500];
 $plugin->cron      = 0;


### PR DESCRIPTION
This pull request introduces changes to simplify the redirection logic in `middleman.php` and updates the version information in `version.php`. The most important changes are as follows:

### Redirection Logic Simplification:
* [`middleman.php`](diffhunk://#diff-e24accb8e4a548533b3589e1e2b8bd4afa14e246e9eb3892731f50ba8cc79724L45-R45): Replaced the `redirect_message` function with a simpler meta-refresh tag for immediate redirection. This removes the delay and simplifies the code.

### Version Update:
* [`version.php`](diffhunk://#diff-0dc418129946563e59bb69680a5ef0ded4329ed9e56e3d295c25e12ea726726bL28-R28): Updated the plugin version to `2025061300` to reflect the latest changes.